### PR TITLE
Allow packed RGB colors for plotting commands

### DIFF
--- a/yorick/graph.c
+++ b/yorick/graph.c
@@ -388,7 +388,9 @@ YgetColor(Symbol *stack)
     int *color = YGet_I(stack, 0, &dims);
     if (dims && (dims->next || dims->number!=3))
       YError("color must be integer scalar or triple (rgb)");
-    return dims? P_RGB(color[0],color[1],color[2]) : (color[0]&0xff);
+    if (dims) return P_RGB(color[0],color[1],color[2]);
+    if (color[0] < 256) return (color[0]&0xff); /* indexed color */
+    return ((color[0]&0xffffff) | 0x01000000);  /* reform packed RGB color */
   }
 }
 


### PR DESCRIPTION
This is a small change to let the `color` graphic keyword accepts packed RGB colors.  This somewhat unifies the color values which are recognized by the plotting commands (without the patch, only color names, indexed colors or RBG triplets) and the ones recognized by the Gist style sheets (only indexed or packed RGB).  In *Play* (the portability library used by Yorick) the packed RGB colors are stored into 32-bit integers defined as (see macro `P_RGB` in `play.h`):
```
0x01000000 | (blue << 16) | (green << 8) | red
```
they are distinguished from indexed colors which are integers strictly less than 256 for which only the least significant byte does matter (see macros `P_IS_RGB` and  `P_IS_NDX` in `play.h`).