### PR TITLE
Fix a bug and many compilation warnings in Yorick

### DIFF
--- a/gist/cgmin.c
+++ b/gist/cgmin.c
@@ -663,7 +663,7 @@ n_fread(void *ptr, unsigned long nbytes, CGM *cgm)
     }
   } else {
     return n_fskip(ptr, nbytes, cgm);
-  }           
+  }
 }
 
 static int
@@ -1335,7 +1335,7 @@ static void GSetClip(int on)
     } else {
       gistT.viewport.xmin= gistT.window.xmin= xbox[1];
       gistT.viewport.xmax= gistT.window.xmax= xbox[0];
-    }    
+    }
     if (ybox[0]<ybox[1]) {
       gistT.viewport.ymin= gistT.window.ymin= ybox[0];
       gistT.viewport.ymax= gistT.window.ymax= ybox[1];
@@ -2354,10 +2354,8 @@ static int DoClass5(int id, long nOctets)
   case 31:  /* FILL REFERENCE POINT */
     nOctets= ReadParameters(nOctets, (void *)0, 0L);
     if (!vdcIllegible && nOctets==4) {
-      short refp[2];
-      refp[0]= Snarf16(paramList);
-      refp[1]= Snarf16(paramList+2);
-      /* ConvertPoints(1L, refp, &gistA.f.refpX, &gistA.f.refpY); */
+      (void)Snarf16(paramList);
+      (void)Snarf16(paramList+2);
     }
     break;
 
@@ -2368,7 +2366,6 @@ static int DoClass5(int id, long nOctets)
   case 33:  /* PATTERN SIZE */
     nOctets= ReadParameters(nOctets, (void *)0, 0L);
     if (!vdcIllegible && nOctets==8) {
-      short hw[2];
       short hx= Snarf16(paramList);
       short hy= Snarf16(paramList+2);
       short wx= Snarf16(paramList+4);
@@ -2377,11 +2374,6 @@ static int DoClass5(int id, long nOctets)
       if (hy<0) hy= -hy;
       if (wx<0) wx= -wx;
       if (wy<0) wy= -wy;
-      if (wx<hx) hw[0]= hx;
-      else hw[0]= wx;
-      if (hy<wy) hw[1]= wy;
-      else hw[1]= hy;
-      /* ConvertPoints(1L, hw, &gistA.f.sizeX, &gistA.f.sizeY); */
     }
     break;
 

--- a/gist/clip.c
+++ b/gist/clip.c
@@ -664,9 +664,9 @@ int ClipFilled(const GpReal* xx, const GpReal* yy, int nn)
       goto chkcls;
     }
     nwork= 1;
-    wind0= wind; /* save for closure calculation */
-    side0= side;
   }
+  wind0= wind; /* save for closure calculation */
+  side0= side;
 
   for (;;) {
     /* Find the next exit point. */

--- a/gist/gtext.c
+++ b/gist/gtext.c
@@ -9,8 +9,7 @@
  */
 
 #include "gtext.h"
-
-extern long strcspn(const char *, const char *);
+#include <string.h>
 
 int gtDoEscapes= 1;
 

--- a/hex/yhex.c
+++ b/hex/yhex.c
@@ -105,19 +105,19 @@ YHX_mesh *new_YHX(double *xyz, long *bound, long nbnds, HX_blkbnd *bnds,
   mesh->mesh.start= start;
   if (xyz) {
     ary= Pointee(xyz);
-    Ref(ary);
+    (void)Ref(ary);
   }
   if (bound) {
     ary= Pointee(bound);
-    Ref(ary);
+    (void)Ref(ary);
   }
   if (bnds) {
     ary= Pointee(bnds);
-    Ref(ary);
+    (void)Ref(ary);
   }
   if (blks) {
     ary= Pointee(blks);
-    Ref(ary);
+    (void)Ref(ary);
   }
   return mesh;
 }

--- a/play/unix/usock.c
+++ b/play/unix/usock.c
@@ -202,7 +202,7 @@ psckt_accept(psckt_t *listener, char **ppeer, void *ctx, psckt_cb_t *callback)
   struct sockaddr *psad = (struct sockaddr *)&sad;
   char host[NI_MAXHOST];
   psckt_t *sock = p_malloc(sizeof(psckt_t));
-  int sfd, lfd = sock->fd;
+  int sfd;
 
   *ppeer = 0;
   if (listener->peer || !sock) {  /* listeners have no peer */
@@ -263,7 +263,7 @@ psckt_recv(psckt_t *sock, void *msg, long len)
     if (n == 0) {  /* socket closed */
       /* socket may close for recv but not for send, not full shutdown yet */
       if (sock->callback) { /* ...but remove from event sources immediately */
-        sock->callback = 0; 
+        sock->callback = 0;
         u_event_src(sock->fd, 0, sock);
       }
       break;

--- a/play/x11/pals.c
+++ b/play/x11/pals.c
@@ -134,7 +134,7 @@ p_palette(p_win *w, p_col_t *colors, int n)
        *     important permanent apps (window manager) started first
        *     -- allocate colors at bottom same as in default cmap */
       for (i=0 ; i<map_size ; i++) used[i] = 0;
-      for (i=0 ; i<16 ; i++)
+      for (i=0 ; i<14 ; i++)
         if (s->colors[i].pixel<map_size) used[s->colors[i].pixel] = 1;
       for (p=map_size-1,i=0 ; p>=0 && i<n ; p--) {
         if (used[p]) continue;

--- a/yorick/binpdb.c
+++ b/yorick/binpdb.c
@@ -33,7 +33,7 @@ int yPDBopen= 010;  /* option bits to alter PDB behavior on open:
                        if either of bits 001 or 002 is set, when a
                        PDB file is opened, its Major-Order: extra
                        may be altered as follows:
-                       001  Major-Order:102 always 
+                       001  Major-Order:102 always
                        002  Major-Order:  opposite from what file says
                        003  Major-Order:101 always
 
@@ -768,7 +768,7 @@ static void RDextras(IOStream *file, long address)
 
     } else if (strncmp(line, "Struct-Align:", 13L)==0 ||
                strncmp(line, "Struct-Alignment:", 17L)==0) {
-      long structAlign;
+      long structAlign = 0;
       TokenAsLong(line[13]!='e'? &line[13]:&line[17], &structAlign);
       if (structAlign<=0) structAlign= 1;
       file->structAlign= (int)structAlign;
@@ -2843,7 +2843,7 @@ static int BlocksVerify(void)
 {
   char *line;
   int illegal=0, skip=0, hadBlocks=0;
-  long i, n, count, addr, minAddr=0, delAddr=0, nGoofs=0;
+  long i, n=0, count, addr=0, minAddr=0, delAddr=0, nGoofs=0;
   long have=0, need= blocksTable.nItems;
 
   if (need) {

--- a/yorick/clog.c
+++ b/yorick/clog.c
@@ -654,8 +654,8 @@ static int CLdimension(CLbuffer *clBuffer, long *length,
 static int CLdims(CLbuffer *clBuffer)
 {
   /* fetch a dimension_spec -- a sequence of dimension specifiers */
-  long origin, length;
-  int tokType, flag;
+  long origin=0, length=0;
+  int tokType, flag=0;
   Dimension *prev, *dims= tmpDims;
 
   /* clear any previous temporary dimension */
@@ -682,7 +682,7 @@ static int CLfile(CLbuffer *clBuffer, IOStream *file)
   int tokType= CLnextToken(clBuffer);
 
   while (tokType>0) {
-    
+
     if ((tokType=='+' || tokType=='-') &&
         CLnextToken(clBuffer)==TOK_IDENTIFIER) {
       if (tokType=='+') {
@@ -728,7 +728,7 @@ static int CLhistory(CLbuffer *clBuffer, HistoryInfo *history)
   int tokType= CLnextToken(clBuffer);
 
   while (tokType>0) {
-    
+
     if (tokType=='+' && CLnextToken(clBuffer)==TOK_IDENTIFIER &&
         CLidMatch("record", clBuffer)) {
       /* +record */
@@ -903,7 +903,7 @@ static int CLdefine(CLbuffer *clBuffer, IOStream *file)
         +define string standard
         +define pointer standard
    */
-  long size, alignment, order;
+  long size=0, alignment=0, order;
   int replacing, flag, tokType, seqFlag;
   StructDef *base;
   FPLayout fpLayout;
@@ -1058,7 +1058,7 @@ static int CLalign(CLbuffer *clBuffer, IOStream *file)
         +align ("variables" | "structs") [alignment]
    */
   int flag;
-  long alignment;
+  long alignment=0;
 
   if (CLnextToken(clBuffer)!=TOK_IDENTIFIER) return -500;
   if (CLidMatch("variables", clBuffer)) flag= 1;

--- a/yorick/graph.c
+++ b/yorick/graph.c
@@ -4095,7 +4095,7 @@ my_rgb_read(Engine *eng, GpColor *rgb, long *nx, long *ny)
 /*--------------------------------------------------------------------------*/
 
 void
-Y_current_mouse(argc)
+Y_current_mouse(int argc)
 {
 #ifdef NO_XLIB
   PushDataBlock(RefNC(&nilDB));

--- a/yorick/socky.c
+++ b/yorick/socky.c
@@ -216,7 +216,6 @@ static void
 ys_on_extract(void *uo, char *name)
 {
   ys_data_t *s = uo;
-  void *cb = 0;
   if (!strcmp(name, "port")) {
     ypush_long(s->port);
   } else if (!strcmp(name, "peer")) {
@@ -266,7 +265,6 @@ static void
 ys_callback(psckt_t *sock, void *ctx)
 {
   ys_data_t *s = ctx;
-  void *task = 0;
   if (ys_icallback < 0) ys_icallback = yfind_global("_socket_callback",0);
   if (ys_isocket < 0) ys_isocket = yfind_global("_socket_socket",0);
   if (ys_icaller < 0) ys_icaller = yfind_global("_socket_caller",0);

--- a/yorick/std2.c
+++ b/yorick/std2.c
@@ -512,7 +512,7 @@ void Y_set_filesize(int nArgs)
 }
 
 static long y_legal_blksz(long nbytes);
-static long 
+static long
 y_legal_blksz(long nbytes)
 {
   long size = 4096;
@@ -815,7 +815,6 @@ Y_fd_close(int argc)
   if (argc == 1) {
     int i = yfd_find(ygets_l(0), 0);
     if (i >= 0) {
-      p_file *f = yfd_list[i].f;
       yfd_list[i].f = 0;
       for (i++ ; i<16 && yfd_list[i].f ; i++) {
         yfd_list[i-1].fd = yfd_list[i].fd;

--- a/yorick/yapi.c
+++ b/yorick/yapi.c
@@ -838,6 +838,8 @@ ygeta_array(int iarg, Operations **pops, Member **ptype)
   }
 
   y_error("expecting array argument");
+  *pops = NULL;
+  *ptype = NULL;
   return 0;
 }
 
@@ -1283,7 +1285,7 @@ void *ypush_obj(y_userobj_t *uo_type, unsigned long size)
     Operations *ops = p_malloc(sizeof(Operations));
     memcpy(ops, &y_uo_ops, sizeof(Operations));
     ops->typeName = uo_type->type_name;
-    uo_type->uo_ops = ops; /* AFTER ops properly initialized */ 
+    uo_type->uo_ops = ops; /* AFTER ops properly initialized */
   }
   uo = p_malloc(sizeof(y_uo_t) - sizeof(union y_uo_body_t) + size);
   memset(uo, 0, sizeof(y_uo_t) - sizeof(union y_uo_body_t) + size);
@@ -1311,7 +1313,7 @@ yfunc_obj(y_userobj_t *uo_type)
     memcpy(ops, &y_uo_ops, sizeof(Operations));
     ops->Setup = y_setup_func_hack;
     ops->typeName = uo_type->type_name;
-    uo_type->uo_ops = ops; /* AFTER ops properly initialized */ 
+    uo_type->uo_ops = ops; /* AFTER ops properly initialized */
   }
   return uo_type;
 }

--- a/yorick/ystr.c
+++ b/yorick/ystr.c
@@ -811,7 +811,7 @@ Y_strfind(int argc)
 {
   void (*searcher)(ys_state_t *state, char *str);
   int keys[YS_MAX_KEYS];
-  long i, nstr, *o;
+  long i, nstr, *o=NULL;
   char *str, **s=0;
   int iarg;
   ys_iter_t iter;
@@ -987,7 +987,7 @@ void
 Y_strgrep(int argc)
 {
   int keys[YS_MAX_KEYS-1];
-  long i, j, is, ntot, nstr, nsub=1, *sub=0, *o;
+  long i, j, is, ntot, nstr, nsub=1, *sub=0, *o=NULL;
   long default_sub[1];
   char *str, **s=0;
   int iarg;


### PR DESCRIPTION
This PR is an attempt to fix a bug in play/x11/pals.c (the number of standard colors is 14 not 16) and many compilation warnings, notably about unused or uninitialized variables.